### PR TITLE
Add support for sprite rotation

### DIFF
--- a/internal/opengl/shaders/default.vert
+++ b/internal/opengl/shaders/default.vert
@@ -16,6 +16,7 @@ out vec2 texCoords;
 
 void main() {
     vec4 pos = vec4(VertexPosition.x, VertexPosition.y, 0.0, 1.0);
+    pos = rotation * pos;
     pos.x += offset.x;
     pos.y -= offset.y;
 
@@ -25,7 +26,7 @@ void main() {
     modelView[1].xyz = vec3( 0.0, 1.0, 0.0 );
     modelView[2].xyz = vec3( 0.0, 0.0, 1.0 );
 
-    gl_Position = projection * modelView * (rotation * pos);
+    gl_Position = projection * modelView * pos;
 
     fragColor = VertexColor;
     texCoords = VertexTexCoord;

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -102,9 +102,7 @@ func (s *CharacterRenderSystem) renderAttachment(
 
 	var idx int
 
-	if elem != character.AttachmentShadow {
-		idx = int(char.ActionIndex) + (int(char.Direction)+directiontype.DirectionTable[FixedCameraDirection])%8
-	}
+	idx = (int(char.ActionIndex) + (int(char.Direction)+directiontype.DirectionTable[FixedCameraDirection])%8) % len(actions)
 
 	action := actions[idx]
 	frameCount := int64(len(action.Frames))
@@ -181,6 +179,7 @@ func (s *CharacterRenderSystem) renderLayer(
 	width, height := float32(frame.Width), float32(frame.Height)
 	width *= layer.Scale[0] * SpriteScaleFactor * graphic.OnePixelSize
 	height *= layer.Scale[1] * SpriteScaleFactor * graphic.OnePixelSize
+	rot := float64(layer.Angle) * (math.Pi / 180)
 
 	offset = [2]float32{
 		(float32(layer.Position[0]) + offset[0]) * graphic.OnePixelSize,
@@ -194,7 +193,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		Size:            mgl32.Vec2{width, height},
 		Position:        char.Position(),
 		Offset:          mgl32.Vec2{offset[0], offset[1]},
-		RotationRadians: 0,
+		RotationRadians: float32(rot),
 		Texture:         texture,
 		FlipVertically:  layer.Mirrored,
 	})

--- a/internal/system/opengl_render_system.go
+++ b/internal/system/opengl_render_system.go
@@ -63,7 +63,7 @@ func (s *OpenGLRenderSystem) Update(dt float32) {
 			gl.Uniform2fv(offsetu, 1, &cmd.Offset[0])
 
 			iden := mgl32.Ident4()
-			rotation := iden.Mul4(mgl32.HomogRotate3D(0, graphic.Forward))
+			rotation := iden.Mul4(mgl32.HomogRotate3D(cmd.RotationRadians, graphic.Backwards))
 			rotationu := gl.GetUniformLocation(s.gls.Program().ID(), gl.Str("rotation\x00"))
 			gl.UniformMatrix4fv(rotationu, 1, false, &rotation[0])
 

--- a/pkg/fileformat/act/act_file.go
+++ b/pkg/fileformat/act/act_file.go
@@ -242,7 +242,7 @@ func (f *ActionFile) loadActionFrameLayers(buf io.ReadSeeker) []*ActionFrameLaye
 			Index:            int32(i),
 			Position:         pos,
 			SpriteFrameIndex: spriteFrameIndex,
-			Mirrored:         mirrored != 1,
+			Mirrored:         mirrored != 0,
 			Scale:            scale,
 			Color:            &color.RGBA{R: r, G: g, B: b, A: a},
 			Angle:            angle,

--- a/pkg/graphic/sprite.go
+++ b/pkg/graphic/sprite.go
@@ -16,10 +16,10 @@ func NewSprite(width, height float32, texture *Texture) *Sprite {
 	h := height / 2
 
 	positions := []float32{
-		+w, +h, 0, // top-left
-		-w, -h, 0, // bottom-right
-		+w, -h, 0, // bottom-left
-		-w, +h, 0, // top-right
+		-w, +h, 0, // top-left
+		+w, -h, 0, // bottom-right
+		-w, -h, 0, // bottom-left
+		+w, +h, 0, // top-right
 	}
 	colors := []float32{
 		1, 1, 1,

--- a/pkg/graphic/transform.go
+++ b/pkg/graphic/transform.go
@@ -5,9 +5,10 @@ import (
 )
 
 var (
-	Origin  = mgl32.Vec3{0, 0, 0}
-	Up      = mgl32.Vec3{0, 1, 0}
-	Forward = mgl32.Vec3{0, 0, 1}
+	Origin    = mgl32.Vec3{0, 0, 0}
+	Up        = mgl32.Vec3{0, 1, 0}
+	Forward   = mgl32.Vec3{0, 0, 1}
+	Backwards = mgl32.Vec3{0, 0, -1}
 )
 
 type Transform struct {


### PR DESCRIPTION
While implementing support for shield, I found out that the following problems :
1) Mirroring logic was upside down (pun intended)
2) Sprite rotation was not correct, it was rotating after applying the offset, so the axis was not the center of the sprite

Please check it out, and let the discussion begin :P