### PR TITLE
Simplify char rendering logic

### DIFF
--- a/internal/component/character_sprite_render_info_component.go
+++ b/internal/component/character_sprite_render_info_component.go
@@ -1,10 +1,9 @@
 package component
 
 import (
+	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"time"
 
-	"github.com/project-midgard/midgarts/pkg/character"
-	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"github.com/project-midgard/midgarts/pkg/character/directiontype"
 )
 
@@ -14,12 +13,12 @@ type CharacterSpriteRenderInfoComponentFace interface {
 
 type CharacterSpriteRenderInfoComponent struct {
 	ActionIndex        actionindex.Type
+	AnimationDelay     time.Duration
 	AnimationEndsAt    time.Time
 	AnimationStartedAt time.Time
 	Direction          directiontype.Type
 	ForcedDuration     time.Duration
 	FPSMultiplier      float64
-	AttachmentType     character.AttachmentType
 	IsStandingBy       bool
 }
 

--- a/internal/component/character_sprite_render_info_component.go
+++ b/internal/component/character_sprite_render_info_component.go
@@ -1,9 +1,9 @@
 package component
 
 import (
-	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"time"
 
+	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"github.com/project-midgard/midgarts/pkg/character/directiontype"
 )
 

--- a/internal/system/character_action_system.go
+++ b/internal/system/character_action_system.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"log"
 	"strconv"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/EngoEngine/engo/common"
 	"github.com/project-midgard/midgarts/internal/component"
 	"github.com/project-midgard/midgarts/internal/entity"
+	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"github.com/project-midgard/midgarts/pkg/character/statetype"
 	"github.com/project-midgard/midgarts/pkg/fileformat/grf"
 )

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -189,7 +189,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		return
 	}
 
-	texture, err := graphic.NewTextureFromImage(spr.ImageAt(int(frameIndex)))
+	texture, err := graphic.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -40,6 +40,7 @@ type CharacterRenderSystem struct {
 }
 
 func NewCharacterRenderSystem(grfFile *grf.File) *CharacterRenderSystem {
+
 	return &CharacterRenderSystem{
 		grfFile:    grfFile,
 		characters: map[string]*entity.Character{},
@@ -111,7 +112,6 @@ func (s *CharacterRenderSystem) renderAttachment(
 	elem character.AttachmentType,
 	offset *[2]float32,
 ) {
-	char.AttachmentType = elem
 
 	var actions []*act.Action
 	if actions = char.Files[elem].ACT.Actions; len(actions) == 0 {
@@ -174,6 +174,8 @@ func (s *CharacterRenderSystem) renderAttachment(
 			float32(frame.Positions[0][1]),
 		}
 	}
+
+	char.AnimationDelay = time.Duration(action.DurationMilliseconds) * time.Millisecond
 }
 
 func (s *CharacterRenderSystem) renderLayer(
@@ -187,7 +189,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		return
 	}
 
-	texture, err := graphic.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
+	texture, err := graphic.NewTextureFromImage(spr.ImageAt(int(frameIndex)))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
If I understood it correctly, the CharacterActionSystem does not need to be aware of AttachmentType, only  of the animation delay.

This simplifies the action state logic a bit IMO

