### PR TITLE
Fix memory leaks

### DIFF
--- a/cmd/grfexplorer/grfexplorer.go
+++ b/cmd/grfexplorer/grfexplorer.go
@@ -162,7 +162,7 @@ func loadImage(name string) *g.Texture {
 	//img = transform.Resize(img, img.Bounds().Max.X*mul, img.Bounds().Max.Y*mul, transform.Linear)
 
 	go func() {
-		spriteTexture, _ = g.NewTextureFromRgba(img)
+		spriteTexture, _ = g.NewTextureFromRgba(img.RGBA)
 		imageWidget = g.Image(spriteTexture).Size(float32(img.Bounds().Max.X), float32(img.Bounds().Max.Y))
 		loadedImageName = name
 	}()

--- a/cmd/sdlclient/main.go
+++ b/cmd/sdlclient/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/project-midgard/midgarts/pkg/character/statetype"
 	"github.com/project-midgard/midgarts/pkg/fileformat/gnd"
 	"github.com/project-midgard/midgarts/pkg/fileformat/grf"
+	"github.com/project-midgard/midgarts/pkg/graphic/caching"
 	"github.com/veandco/go-sdl2/sdl"
 )
 
@@ -90,7 +91,7 @@ func main() {
 	ks := window.NewKeyState(win)
 
 	w := ecs.World{}
-	renderSys := system.NewCharacterRenderSystem(grfFile)
+	renderSys := system.NewCharacterRenderSystem(grfFile, caching.NewCachedTextureProvider())
 	actionSystem := system.NewCharacterActionSystem(grfFile)
 
 	c1 := entity.NewCharacter(character.Male, jobspriteid.Blacksmith, 23)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/EngoEngine/engo v1.0.5
 	github.com/go-gl/gl v0.0.0-20210426225639-a3bfa832c8aa
 	github.com/go-gl/mathgl v1.0.0
+	github.com/google/uuid v1.2.0
 	github.com/joho/godotenv v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hajimehoshi/go-mp3 v0.2.1 h1:DH4ns3cPv39n3cs8MPcAlWqPeAwLCK8iNgqvg0QBWI8=
 github.com/hajimehoshi/go-mp3 v0.2.1/go.mod h1:Rr+2P46iH6PwTPVgSsEwBkon0CK5DxCAeX/Rp65DCTE=
 github.com/hajimehoshi/oto v0.3.4/go.mod h1:PgjqsBJff0efqL2nlMJidJgVJywLn6M4y8PI4TfeWfA=

--- a/internal/component/character_sprite_render_info_component.go
+++ b/internal/component/character_sprite_render_info_component.go
@@ -1,10 +1,9 @@
 package component
 
 import (
+	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"time"
 
-	"github.com/project-midgard/midgarts/pkg/character"
-	"github.com/project-midgard/midgarts/pkg/character/actionindex"
 	"github.com/project-midgard/midgarts/pkg/character/directiontype"
 )
 
@@ -14,12 +13,12 @@ type CharacterSpriteRenderInfoComponentFace interface {
 
 type CharacterSpriteRenderInfoComponent struct {
 	ActionIndex        actionindex.Type
+	AnimationDelay     time.Duration
 	AnimationEndsAt    time.Time
 	AnimationStartedAt time.Time
 	Direction          directiontype.Type
 	ForcedDuration     time.Duration
 	FPSMultiplier      float64
-	AttachmentType     character.AttachmentType
 	IsStandingBy       bool
 }
 

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -189,7 +189,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		return
 	}
 
-	texture, err := graphic.NewTextureFromImage(spr.ImageAt(int(frameIndex)))
+	texture, err := graphic.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -40,6 +40,7 @@ type CharacterRenderSystem struct {
 }
 
 func NewCharacterRenderSystem(grfFile *grf.File) *CharacterRenderSystem {
+
 	return &CharacterRenderSystem{
 		grfFile:    grfFile,
 		characters: map[string]*entity.Character{},
@@ -111,7 +112,6 @@ func (s *CharacterRenderSystem) renderAttachment(
 	elem character.AttachmentType,
 	offset *[2]float32,
 ) {
-	char.AttachmentType = elem
 
 	var actions []*act.Action
 	if actions = char.Files[elem].ACT.Actions; len(actions) == 0 {
@@ -174,6 +174,8 @@ func (s *CharacterRenderSystem) renderAttachment(
 			float32(frame.Positions[0][1]),
 		}
 	}
+
+	char.AnimationDelay = time.Duration(action.DurationMilliseconds) * time.Millisecond
 }
 
 func (s *CharacterRenderSystem) renderLayer(
@@ -187,7 +189,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		return
 	}
 
-	texture, err := graphic.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
+	texture, err := graphic.NewTextureFromImage(spr.ImageAt(int(frameIndex)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/system/character_render_system.go
+++ b/internal/system/character_render_system.go
@@ -34,19 +34,20 @@ type CharacterRenderable interface {
 }
 
 type CharacterRenderSystem struct {
-	grfFile        *grf.File
-	characters     map[string]*entity.Character
-	RenderCommands *RenderCommands
+	grfFile         *grf.File
+	characters      map[string]*entity.Character
+	RenderCommands  *RenderCommands
+	textureProvider graphic.TextureProvider
 }
 
-func NewCharacterRenderSystem(grfFile *grf.File) *CharacterRenderSystem {
-
+func NewCharacterRenderSystem(grfFile *grf.File, textureProvider graphic.TextureProvider) *CharacterRenderSystem {
 	return &CharacterRenderSystem{
 		grfFile:    grfFile,
 		characters: map[string]*entity.Character{},
 		RenderCommands: &RenderCommands{
 			sprite: []rendercmd.SpriteRenderCommand{},
 		},
+		textureProvider: textureProvider,
 	}
 }
 
@@ -189,7 +190,7 @@ func (s *CharacterRenderSystem) renderLayer(
 		return
 	}
 
-	texture, err := graphic.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
+	texture, err := s.textureProvider.NewTextureFromRGBA(spr.ImageAt(int(frameIndex)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/graphic/caching/texture.go
+++ b/pkg/graphic/caching/texture.go
@@ -1,0 +1,26 @@
+package caching
+
+import (
+	"github.com/google/uuid"
+	"github.com/project-midgard/midgarts/pkg/graphic"
+)
+
+type CachedTextureProvider map[uuid.UUID]*graphic.Texture
+
+func NewCachedTextureProvider() CachedTextureProvider {
+	return make(map[uuid.UUID]*graphic.Texture)
+}
+
+func (t CachedTextureProvider) NewTextureFromRGBA(rgba *graphic.UniqueRGBA) (*graphic.Texture, error) {
+	if txt, ok := t[rgba.ID]; ok {
+		return txt, nil
+	}
+
+	tex, err := graphic.NewTextureFromRGBA(rgba)
+	if err != nil {
+		return nil, err
+	}
+
+	t[rgba.ID] = tex
+	return tex, nil
+}

--- a/pkg/graphic/rgba.go
+++ b/pkg/graphic/rgba.go
@@ -1,0 +1,18 @@
+package graphic
+
+import (
+	"github.com/google/uuid"
+	"image"
+)
+
+type UniqueRGBA struct {
+	ID uuid.UUID
+	*image.RGBA
+}
+
+func NewUniqueRGBA(r image.Rectangle) *UniqueRGBA {
+	return &UniqueRGBA{
+		ID:   uuid.New(),
+		RGBA: image.NewRGBA(r),
+	}
+}

--- a/pkg/graphic/sprite.go
+++ b/pkg/graphic/sprite.go
@@ -6,21 +6,40 @@ import (
 )
 
 type Sprite struct {
+	positions []float32
 	*Graphic
 	Texture *Texture
 }
 
-func NewSprite(width, height float32, texture *Texture) *Sprite {
-	geom := NewGeometry()
+func (s *Sprite) SetBounds(width, height float32) {
 	w := width / 2
 	h := height / 2
 
-	positions := []float32{
-		-w, +h, 0, // top-left
-		+w, -h, 0, // bottom-right
-		-w, -h, 0, // bottom-left
-		+w, +h, 0, // top-right
+	s.positions[0] = -w
+	s.positions[3] = w
+	s.positions[6] = -w
+	s.positions[9] = w
+
+	s.positions[1] = h
+	s.positions[4] = -h
+	s.positions[7] = -h
+	s.positions[10] = h
+}
+
+func (s *Sprite) SetTexture(text *Texture) {
+	s.Texture = text
+}
+
+func NewSprite(width, height float32, texture *Texture) *Sprite {
+	s := &Sprite{
+		positions: make([]float32, 12),
+		Texture:   texture,
 	}
+
+	s.SetBounds(width, height)
+
+	geom := NewGeometry()
+
 	colors := []float32{
 		1, 1, 1,
 		1, 1, 1,
@@ -35,7 +54,7 @@ func NewSprite(width, height float32, texture *Texture) *Sprite {
 	}
 
 	geom.AddVBO(opengl.NewVBO([opengl.NumVertexAttributes][]float32{
-		positions,
+		s.positions,
 		colors,
 		texCoords,
 	}).AddAttribute(opengl.VertexPosition).
@@ -43,8 +62,6 @@ func NewSprite(width, height float32, texture *Texture) *Sprite {
 		AddAttribute(opengl.VertexTexCoord),
 	).SetIndices(0, 1, 2, 3, 1, 0)
 
-	return &Sprite{
-		Graphic: NewGraphic(geom, gl.TRIANGLES),
-		Texture: texture,
-	}
+	s.Graphic = NewGraphic(geom, gl.TRIANGLES)
+	return s
 }

--- a/pkg/graphic/texture.go
+++ b/pkg/graphic/texture.go
@@ -11,14 +11,22 @@ import (
 type Texture struct {
 	handle                        uint32
 	path                          string
-	img                           *image.RGBA
 	width, height, internalFormat int32
 	format, formatType            uint32
 	magFilter, minFilter          int32
 	wrapS, wrapT                  int32
 }
 
-func NewTextureFromRGBA(rgba *image.RGBA) (tex *Texture, err error) {
+func (t *Texture) Bind(unit uint32) {
+	gl.ActiveTexture(gl.TEXTURE0 + unit)
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+}
+
+type TextureProvider interface {
+	NewTextureFromRGBA(rgba *UniqueRGBA) (tex *Texture, err error)
+}
+
+func NewTextureFromRGBA(rgba *UniqueRGBA) (tex *Texture, err error) {
 	if rgba.Stride != rgba.Rect.Size().X*4 {
 		return nil, fmt.Errorf("unsupported stride")
 	}
@@ -31,7 +39,6 @@ func NewTextureFromRGBA(rgba *image.RGBA) (tex *Texture, err error) {
 		internalFormat: gl.RGBA8,
 		format:         gl.RGBA,
 		formatType:     gl.UNSIGNED_BYTE,
-		img:            rgba,
 		magFilter:      gl.NEAREST,
 		minFilter:      gl.NEAREST,
 		wrapS:          gl.CLAMP_TO_BORDER,
@@ -61,9 +68,4 @@ func NewTextureFromRGBA(rgba *image.RGBA) (tex *Texture, err error) {
 	)
 
 	return
-}
-
-func (t *Texture) Bind(unit uint32) {
-	gl.ActiveTexture(gl.TEXTURE0 + unit)
-	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 }


### PR DESCRIPTION
**Depends on https://github.com/drgomesp/midgarts/pull/18**

This MR proposes 

1. Caching textures for the same RGBA;
2. Instead of allocating new sprites, re-use their buffers on each update - This is a requirement for 3
3. Only invoke `gl.GenBuffers(int32(NumVertexAttributes), &vbo.handles[loc])` the first time the object is rendered.

This fixed the memory leakage in my testing environment (mingw + sdl2 + win64)
