### PR TITLE
pins game window to the top right

### DIFF
--- a/cmd/sdlclient/main.go
+++ b/cmd/sdlclient/main.go
@@ -52,11 +52,16 @@ func main() {
 	}
 	defer sdl.Quit()
 
+	desktop, err := sdl.GetDesktopDisplayMode(0)
+	if err != nil {
+		log.Fatal().Err(err).Msg("getting desktop display mode")
+	}
+
 	var win *sdl.Window
 	if win, err = sdl.CreateWindow(
 		fmt.Sprintf("Midgarts Client - %s", version.Get()),
-		sdl.WINDOWPOS_UNDEFINED,
-		sdl.WINDOWPOS_UNDEFINED,
+		desktop.W-WindowWidth,
+		0,
 		WindowWidth,
 		WindowHeight,
 		sdl.WINDOW_OPENGL,


### PR DESCRIPTION
I found this was helpful with development, as the reload window would always show up in the middle of my screen on top of my editor.