### PR TITLE
removes encoders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/AllenDang/giu v0.7.0
 	github.com/EngoEngine/ecs v1.0.5
+	github.com/atotto/clipboard v0.1.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6
 	github.com/go-gl/mathgl v1.0.0
@@ -15,7 +16,6 @@ require (
 	github.com/rs/zerolog v1.26.1
 	github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf
 	github.com/stretchr/testify v1.8.4
-	github.com/suapapa/go_hangul v1.2.1
 	github.com/veandco/go-sdl2 v0.4.25
 	github.com/xlab/closer v1.1.0
 	golang.org/x/text v0.13.0
@@ -25,7 +25,6 @@ require (
 	github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8 // indirect
 	github.com/AllenDang/imgui-go v1.12.1-0.20221124025851-59b862ca5a0c // indirect
 	github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3 // indirect
 	github.com/go-gl/glfw v0.0.0-20221017161538-93cebf72946b // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/suapapa/go_hangul v1.2.1 h1:HJjhwHM2F2G0zq7uIxDWB7tFtoEq3lbjTJLJ8dH4WRE=
-github.com/suapapa/go_hangul v1.2.1/go.mod h1:o5XMYtsygfiqzOViFb1W5ax+nROPYeUdh5cDGMkMDxo=
 github.com/veandco/go-sdl2 v0.4.25 h1:J5ac3KKOccp/0xGJA1PaNYKPUcZm19IxhDGs8lJofPI=
 github.com/veandco/go-sdl2 v0.4.25/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
 github.com/xlab/android-go v0.0.0-20221014001251-3dab312ceaf9 h1:gGO62iqn+KRAAHuaTj28knIfP5X03pgnLBw8f/XHH7s=


### PR DESCRIPTION
I learnt a lot on this one. 

So when I started my journey to add encoders it was to try and make things more simple. Unfortunately, that's not easily done.

My original implementation attempted to encode the already encoded values (from the `grf` package). Which I learnt cannot be converted back to Korean characters (Korean byte code to Windows1252 loses data(?)).

So the characters meant nothing. When diving deeper I realized before my changes the values were being double encoded (once in the grf package upon loading, and then once when the grfexplorer receive them).

Anyway, this change reverts my changes and fixes up the existing ones to show the expected values Windows1252 values that are used in the grf package.

I think I will try and revisit this in the future so that when a GRF is loaded it records:
1. the bytes
2. the windows1252 encoding
3. the euckr encoding

that way tools can have access to all three.

<img width="533" alt="image" src="https://github.com/drgomesp/midgarts/assets/2105302/f1689bf1-1e34-47a6-9162-5879ae43ee53">
