### PR TITLE
Include korean encodings

### DIFF
--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatal().Err(err).Send()
 	}
 
-	wnd := g.NewMasterWindow("GRF Explorer", 800, 600, g.MasterWindowFlagsNotResizable)
+	wnd := g.NewMasterWindow("GRF Explorer", 800, 600, 0)
 	g.Context.FontAtlas.SetDefaultFontFromBytes(app.font, 16)
 	wnd.Run(app.run)
 }

--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"os"
+	"path/filepath"
 	"strings"
 
 	g "github.com/AllenDang/giu"
@@ -215,6 +216,8 @@ func (app *App) loadFileInfo() {
 		return
 	}
 
+	_, koreanFileName := filepath.Split(app.currentEntry.Name.Korean())
+
 	app.fileInfoWidget = g.Layout{
 		g.Table().
 			Columns(
@@ -224,7 +227,7 @@ func (app *App) loadFileInfo() {
 			Rows(
 				g.TableRow(g.Label("Width").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Width))),
 				g.TableRow(g.Label("Height").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Height))),
-				g.TableRow(g.Label("Korean").Wrapped(true), g.Label(app.currentEntry.Name.Korean())),
+				g.TableRow(g.Label("Korean").Wrapped(true), g.Label(koreanFileName)),
 				g.TableRow(
 					g.Button("Copy Path").OnClick(func() {
 						clipboard.WriteAll(app.currentEntryName)

--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -8,6 +8,7 @@ import (
 
 	g "github.com/AllenDang/giu"
 	"github.com/atotto/clipboard"
+	_ "github.com/joho/godotenv/autoload"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/sqweek/dialog"
@@ -16,6 +17,10 @@ import (
 	"github.com/project-midgard/midgarts/internal/fileformat/act"
 	"github.com/project-midgard/midgarts/internal/fileformat/grf"
 	"github.com/project-midgard/midgarts/internal/fileformat/spr"
+)
+
+var (
+	GrfFilePath = os.Getenv("GRF_FILE_PATH")
 )
 
 type App struct {
@@ -53,9 +58,23 @@ func configureLogger() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 }
 
-func (app *App) loadInitialData() (err error) {
+func (app *App) loadInitialData() error {
+	// loads an embedded font
 	app.font = assets.FreeSans
-	return err
+
+	// respects grf env var (if present)
+	if GrfFilePath != "" {
+		var err error
+		app.grfFile, err = grf.Load(GrfFilePath)
+		if err != nil {
+			log.Warn().Err(err).Msg("Error loading GRF file")
+
+			// nil fail, let the user manually select their grf
+			return nil
+		}
+	}
+
+	return nil
 }
 
 func (app *App) run() {

--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -126,7 +126,7 @@ func (app *App) buildEntryTreeNodes() g.Layout {
 		nodeEntries := make([]any, 0)
 
 		for _, e := range app.grfFile.GetEntries(n.Value) {
-			if strings.Contains(e.Name, ".spr") && strings.Contains(e.Name, app.filter) {
+			if strings.Contains(e.Name.String(), ".spr") && strings.Contains(e.Name.String(), app.filter) {
 				nodeEntries = append(nodeEntries, e.Name)
 			}
 		}
@@ -134,11 +134,12 @@ func (app *App) buildEntryTreeNodes() g.Layout {
 		if len(nodeEntries) > 0 {
 			node := g.TreeNode(fmt.Sprintf("%s (%d)", n.Value, len(nodeEntries)))
 			selectableNodes = g.RangeBuilder("selectableNodes", nodeEntries, func(i int, v interface{}) g.Widget {
+				entryPath := v.(*grf.Path)
 				return g.Style().
 					SetColor(g.StyleColorText, color.RGBA{203, 213, 255, 255}).
 					To(
-						g.Selectable(v.(string)).OnClick(func() {
-							app.onClickEntry(v.(string))
+						g.Selectable(entryPath.String()).OnClick(func() {
+							app.onClickEntry(entryPath.String())
 						}),
 					)
 
@@ -204,9 +205,15 @@ func (app *App) loadFileInfo() {
 			Rows(
 				g.TableRow(g.Label("Width").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Width))),
 				g.TableRow(g.Label("Height").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Height))),
-				g.TableRow(g.Button("Copy File Path").OnClick(func() {
-					clipboard.WriteAll(app.currentEntryName)
-				})),
+				g.TableRow(g.Label("Korean").Wrapped(true), g.Label(app.currentEntry.Name.Korean())),
+				g.TableRow(
+					g.Button("Copy Path").OnClick(func() {
+						clipboard.WriteAll(app.currentEntryName)
+					}),
+					g.Button("Copy Korean Path").OnClick(func() {
+						clipboard.WriteAll(app.currentEntry.Name.Korean())
+					}),
+				),
 			).Flags(g.TableFlagsBordersH),
 	}
 }

--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -36,6 +36,7 @@ type App struct {
 	font             []byte
 	openFileSelector bool
 	filter           string
+	filterByKorean   bool
 }
 
 func main() {
@@ -91,6 +92,7 @@ func (app *App) run() {
 		g.Row(
 			g.Label("Filter:"),
 			g.InputText(&app.filter).Size(200),
+			g.Checkbox("Korean", &app.filterByKorean),
 		),
 		g.SplitLayout(g.DirectionVertical, &app.splitSize, app.buildEntryTreeNodes(), app.fileInfoLayout()),
 		app.fileSelectorModal(),
@@ -146,7 +148,11 @@ func (app *App) buildEntryTreeNodes() g.Layout {
 		nodeEntries := make([]any, 0)
 
 		for _, e := range app.grfFile.GetEntries(n.Value) {
-			if strings.Contains(e.Name.String(), ".spr") && strings.Contains(e.Name.String(), app.filter) {
+			filterValue := e.Name.String()
+			if app.filterByKorean {
+				filterValue = e.Name.Korean()
+			}
+			if strings.Contains(e.Name.String(), ".spr") && strings.Contains(filterValue, app.filter) {
 				nodeEntries = append(nodeEntries, e.Name)
 			}
 		}

--- a/cmd/grfexplorer/main.go
+++ b/cmd/grfexplorer/main.go
@@ -233,7 +233,9 @@ func (app *App) loadFileInfo() {
 			Rows(
 				g.TableRow(g.Label("Width").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Width))),
 				g.TableRow(g.Label("Height").Wrapped(true), g.Label(fmt.Sprintf("%d", sprFile.Frames[0].Height))),
-				g.TableRow(g.Label("Korean").Wrapped(true), g.Label(koreanFileName)),
+				g.TableRow(g.Label("Korean").Wrapped(true), g.Row(g.Label(koreanFileName), g.Button("[C]").OnClick(func() {
+					clipboard.WriteAll(koreanFileName)
+				}))),
 				g.TableRow(
 					g.Button("Copy Path").OnClick(func() {
 						clipboard.WriteAll(app.currentEntryName)

--- a/internal/fileformat/grf/grf_entry.go
+++ b/internal/fileformat/grf/grf_entry.go
@@ -26,7 +26,8 @@ type EntryHeader struct {
 
 // Entry ...
 type Entry struct {
-	Name   string
+	Name *Path
+
 	Header EntryHeader
 	Data   []byte
 }

--- a/internal/fileformat/grf/grf_file_path.go
+++ b/internal/fileformat/grf/grf_file_path.go
@@ -1,0 +1,64 @@
+package grf
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/korean"
+)
+
+type Path struct {
+	bytes       []byte
+	windows1252 string
+	korean      string
+}
+
+func NewFilePath(b []byte) (*Path, error) {
+	p := Path{
+		bytes: b,
+	}
+
+	n, err := charmap.Windows1252.NewDecoder().Bytes(b)
+	if err != nil {
+		return nil, err
+	}
+	p.windows1252 = unixifyPaths(string(n))
+
+	k, err := korean.EUCKR.NewDecoder().Bytes(b)
+	if err != nil {
+		return nil, err
+	}
+
+	p.korean = unixifyPaths(string(k))
+
+	return &p, nil
+}
+
+// String returns the Windows1252 encoded filepath
+func (p Path) String() string {
+	return p.windows1252
+}
+
+// Korean returns the Korean EUCKR encoded filepath
+func (p Path) Korean() string {
+	return p.korean
+}
+
+// Bytes returns the raw grf extracted byte slice of the filepath
+func (p Path) Bytes() []byte {
+	return p.bytes
+}
+
+// Dir returns the Windows1252 directory of the file path
+func (p Path) Dir() string {
+	dir, _ := filepath.Split(p.windows1252)
+	dir = strings.TrimSuffix(dir, `/`)
+	return dir
+}
+
+func unixifyPaths(s string) string {
+	s = strings.ReplaceAll(s, `\`, `/`)
+	s = strings.ToLower(s)
+	return s
+}


### PR DESCRIPTION
This change introduces a "Path" struct to the grf package. I've only applied it to the files, not the directories. 

On creation the original byte slice is saved, and two encodings Windows1252 and EUCKR Korean. There's some utility functions for getting the directory path.

The GrfExplorer is updated with:
- Korean filenames
- Copy File Path (in Korean)
- Filtering the file list against the Korean path
- Copy button for Korean file name

In addition I snuck in two other small changes:
- respecting the grf path env var
- allow the master window to be resized

<img width="802" alt="image" src="https://github.com/drgomesp/midgarts/assets/2105302/dbbb01bc-62ca-4719-a061-519a61fe8f01">
